### PR TITLE
Add 'web_profiler.toolbar.enable' option to disable toolbar

### DIFF
--- a/WebProfilerServiceProvider.php
+++ b/WebProfilerServiceProvider.php
@@ -84,6 +84,8 @@ class WebProfilerServiceProvider implements ServiceProviderInterface, Controller
         $app['web_profiler.controller.exception'] = $app->share(function ($app) {
             return new ExceptionController($app['profiler'], $app['twig'], $app['debug']);
         });
+        
+        $app['web_profiler.toolbar.enable'] = true;
 
         $app['web_profiler.toolbar.listener'] = $app->share(function ($app) {
             return new WebDebugToolbarListener($app['twig']);
@@ -175,7 +177,11 @@ class WebProfilerServiceProvider implements ServiceProviderInterface, Controller
         $dispatcher = $app['dispatcher'];
 
         $dispatcher->addSubscriber($app['profiler.listener']);
-        $dispatcher->addSubscriber($app['web_profiler.toolbar.listener']);
+        
+        if($app['web_profiler.toolbar.enable']) {
+            $dispatcher->addSubscriber($app['web_profiler.toolbar.listener']);
+        }
+        
         $dispatcher->addSubscriber($app['profiler']->get('request'));
         $app->mount($app['profiler.mount_prefix'], $this->connect($app));
     }


### PR DESCRIPTION
The added switch `web_profiler.toolbar.enable` (default: true) allows to disable the debug toolbar on requests without disabling the profiler facility. Requests can still be profiled by using the token (e.g. provided in HTTP Response header) or searching on the profiler page.

The toolbar for a selected token still appears on the profiler page.

Useful for staging / beta environments.
