### PR TITLE
Support symfony 2.4 form profiler panel

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -35,6 +35,11 @@ to enable those if that's not already the case:
     $app->register(new Provider\TwigServiceProvider());
     $app->register(new Provider\UrlGeneratorServiceProvider());
 
+If you are using ``FormServiceProvider``, the ``WebProfilerServiceProvider`` will detect that and
+enable the corresponding panels.
+
+*Make sure to register all other required or used service providers before* ``WebProfilerServiceProvider``.
+
 If you are using ``MonologServiceProvider`` for logs, you must also add
 ``symfony/monolog-bridge`` as a dependency in your ``composer.json`` to get the
 logs in the profiler.

--- a/WebProfilerServiceProvider.php
+++ b/WebProfilerServiceProvider.php
@@ -15,6 +15,10 @@ use Symfony\Bundle\WebProfilerBundle\Controller\ExceptionController;
 use Symfony\Bundle\WebProfilerBundle\Controller\RouterController;
 use Symfony\Bundle\WebProfilerBundle\Controller\ProfilerController;
 use Symfony\Bundle\WebProfilerBundle\EventListener\WebDebugToolbarListener;
+use Symfony\Component\Form\Extension\DataCollector\FormDataCollector;
+use Symfony\Component\Form\Extension\DataCollector\FormDataExtractor;
+use Symfony\Component\Form\Extension\DataCollector\Proxy\ResolvedTypeFactoryDataCollectorProxy;
+use Symfony\Component\Form\Extension\DataCollector\Type\DataCollectorTypeExtension;
 use Symfony\Component\HttpKernel\Profiler\Profiler;
 use Symfony\Component\HttpKernel\EventListener\ProfilerListener;
 use Symfony\Component\HttpKernel\Profiler\FileProfilerStorage;
@@ -60,18 +64,41 @@ class WebProfilerServiceProvider implements ServiceProviderInterface, Controller
             array('time',      '@WebProfiler/Collector/time.html.twig'),
             array('router',    '@WebProfiler/Collector/router.html.twig'),
             array('memory',    '@WebProfiler/Collector/memory.html.twig'),
+            array('form',      '@WebProfiler/Collector/form.html.twig'),
         );
 
-        $app['data_collectors'] = array(
-            'config'    => $app->share(function ($app) { return new ConfigDataCollector(); }),
-            'request'   => $app->share(function ($app) { return new RequestDataCollector(); }),
-            'exception' => $app->share(function ($app) { return new ExceptionDataCollector(); }),
-            'events'    => $app->share(function ($app) { return new EventDataCollector(); }),
-            'logger'    => $app->share(function ($app) { return new LoggerDataCollector($app['logger']); }),
-            'time'      => $app->share(function ($app) { return new TimeDataCollector(null, $app['stopwatch']); }),
-            'router'    => $app->share(function ($app) { return new RouterDataCollector(); }),
-            'memory'    => $app->share(function ($app) { return new MemoryDataCollector(); }),
-        );
+        $app['data_collectors'] = $app->share(function ($app) {
+            return array(
+                'config'    => $app->share(function ($app) { return new ConfigDataCollector(); }),
+                'request'   => $app->share(function ($app) { return new RequestDataCollector(); }),
+                'exception' => $app->share(function ($app) { return new ExceptionDataCollector(); }),
+                'events'    => $app->share(function ($app) { return new EventDataCollector(); }),
+                'logger'    => $app->share(function ($app) { return new LoggerDataCollector($app['logger']); }),
+                'time'      => $app->share(function ($app) { return new TimeDataCollector(null, $app['stopwatch']); }),
+                'router'    => $app->share(function ($app) { return new RouterDataCollector(); }),
+                'memory'    => $app->share(function ($app) { return new MemoryDataCollector(); }),
+            );
+        });
+
+        if (isset($app['form.resolved_type_factory']) && class_exists('\Symfony\Component\Form\Extension\DataCollector\FormDataCollector')) {
+            $app['data_collectors.form.extractor'] = $app->share(function () { return new FormDataExtractor(); });
+
+            $app['data_collectors'] = $app->share($app->extend('data_collectors', function ($collectors, $app) {
+                $collectors['form'] = $app->share(function ($app) { return new FormDataCollector($app['data_collectors.form.extractor']); });
+
+                return $collectors;
+            }));
+
+            $app['form.resolved_type_factory'] = $app->share($app->extend('form.resolved_type_factory', function ($factory, $app) {
+                return new ResolvedTypeFactoryDataCollectorProxy($factory, $app['data_collectors']['form']($app));
+            }));
+
+            $app['form.type.extensions'] = $app->share($app->extend('form.type.extensions', function ($extensions, $app) {
+                $extensions[] = new DataCollectorTypeExtension($app['data_collectors']['form']($app));
+
+                return $extensions;
+            }));
+        }
 
         $app['web_profiler.controller.profiler'] = $app->share(function ($app) {
             return new ProfilerController($app['url_generator'], $app['profiler'], $app['twig'], $app['data_collector.templates'], $app['web_profiler.debug_toolbar.position']);


### PR DESCRIPTION
When using Symfony 2.4 and using FormServiceProvider the form profiler panel is added.

The template is registered in any case, as the TemplateManager only tries to load the template if a collector is registered with this name.

**Requires** silexphp/Silex#880 to be merged in order to get this working. It will not break if merged before, but will not be active.
