### PR TITLE
fix issue #37. web profiler bundle 2.4 breaks the profiler page without ...

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "silex/silex": "~1.0",
-        "symfony/web-profiler-bundle": ">=2.5,<3.0",
+        "symfony/web-profiler-bundle": "v2.4.5",
         "symfony/stopwatch": "~2.2"
     },
     "autoload": {


### PR DESCRIPTION
issue #37 caused by commit 03bd481db18f5c8d4f962625e542bb8bcc0fc4ca on line 242 of the web profiler bundle controller. This commit is included in version 2.4.4
