### PR TITLE
Record events

### DIFF
--- a/WebProfilerServiceProvider.php
+++ b/WebProfilerServiceProvider.php
@@ -51,7 +51,6 @@ class WebProfilerServiceProvider implements ServiceProviderInterface, Controller
         $app['profiler.mount_prefix'] = '/_profiler';
         $app['dispatcher'] = $app->share($app->extend('dispatcher', function ($dispatcher, $app) {
             $dispatcher = new TraceableEventDispatcher($dispatcher, $app['stopwatch'], $app['logger']);
-            $dispatcher->setProfiler($app['profiler']);
 
             return $dispatcher;
         }));
@@ -73,7 +72,7 @@ class WebProfilerServiceProvider implements ServiceProviderInterface, Controller
                 'config'    => $app->share(function ($app) { return new ConfigDataCollector(); }),
                 'request'   => $app->share(function ($app) { return new RequestDataCollector(); }),
                 'exception' => $app->share(function ($app) { return new ExceptionDataCollector(); }),
-                'events'    => $app->share(function ($app) { return new EventDataCollector(); }),
+                'events'    => $app->share(function ($app) { return new EventDataCollector($app['dispatcher']); }),
                 'logger'    => $app->share(function ($app) { return new LoggerDataCollector($app['logger']); }),
                 'time'      => $app->share(function ($app) { return new TimeDataCollector(null, $app['stopwatch']); }),
                 'router'    => $app->share(function ($app) { return new RouterDataCollector(); }),


### PR DESCRIPTION
Removes a circular dependency (profiler > dispatcher > profiler) and provides dispatcher to `EventDataCollector`. The latter enables recording of events in WebProfiler.

As per `TraceableEventDispatcher` documentation `setProfiler` method has been deprecated since version 2.4, to be removed in 3.0 ( symfony/http-kernel package ). Removing line 54 is _safe_ except for installations having http-kernel 2.3

Related to issue #40
