### PR TITLE
Add missing dependency for HttpFragmentServiceProvider

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,11 +23,12 @@ And enable it in your application:
     ));
 
 The provider depends on ``ServiceControllerServiceProvider``,
-``TwigServiceProvider`` and ``RoutingServiceProvider``, so you also need
+``TwigServiceProvider``, ``HttpFragmentServiceProvider`` and ``RoutingServiceProvider``, so you also need
 to enable those if that's not already the case:
 
 .. code-block:: php
 
+    $app->register(new Provider\HttpFragmentServiceProvider());
     $app->register(new Provider\ServiceControllerServiceProvider());
     $app->register(new Provider\TwigServiceProvider());
     $app->register(new Provider\RoutingServiceProvider());


### PR DESCRIPTION
WebProfilerBundle templates make use of `render` functions. This means it requires the `HttpFragmentServiceProvider` to be enabled. This updates the readme accordingly.
