### PR TITLE
pass request stack to profiler listener

### DIFF
--- a/WebProfilerServiceProvider.php
+++ b/WebProfilerServiceProvider.php
@@ -146,7 +146,8 @@ class WebProfilerServiceProvider implements ServiceProviderInterface, Controller
                 $app['profiler'],
                 $app['profiler.request_matcher'],
                 $app['profiler.only_exceptions'],
-                $app['profiler.only_master_requests']
+                $app['profiler.only_master_requests'],
+                $app['request_stack']
             );
         };
 


### PR DESCRIPTION
Avoids deprecated warning in ProfileListener constructor and preparation for syfmony 3.0 support.

Deprecated: Since version 2.4, the Symfony\Component\HttpKernel\EventListener\ProfilerListener::__construct method must accept a RequestStack instance to get the request instead of using the Symfony\Component\HttpKernel\EventListener\ProfilerListener::onKernelRequest method that will be removed in 3.0. 