### PR TITLE
The current version of the web-profiler breaks on Symfony 2.6 and below.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "silex/silex": "2.0.*@dev",
-        "symfony/web-profiler-bundle": "~2.4",
+        "symfony/web-profiler-bundle": "~2.7",
         "symfony/stopwatch": "~2.2"
     },
     "autoload": {


### PR DESCRIPTION
This is the error message: 

    The profiler template "@WebProfiler/Collector/twig.html.twig" for data collector "twig" does not exist.