### PR TITLE
Fix TwigProfiler for Silex 2 &  Symfony 2.7+

### DIFF
--- a/WebProfilerServiceProvider.php
+++ b/WebProfilerServiceProvider.php
@@ -59,21 +59,25 @@ class WebProfilerServiceProvider implements ServiceProviderInterface, Controller
             return new TraceableEventDispatcher($dispatcher, $app['stopwatch'], $app['logger']);
         });
 
-        $app['data_collector.templates'] = array(
-            array('config',    '@WebProfiler/Collector/config.html.twig'),
-            array('request',   '@WebProfiler/Collector/request.html.twig'),
-            array('exception', '@WebProfiler/Collector/exception.html.twig'),
-            array('events',    '@WebProfiler/Collector/events.html.twig'),
-            array('logger',    '@WebProfiler/Collector/logger.html.twig'),
-            array('time',      '@WebProfiler/Collector/time.html.twig'),
-            array('router',    '@WebProfiler/Collector/router.html.twig'),
-            array('memory',    '@WebProfiler/Collector/memory.html.twig'),
-            array('form',      '@WebProfiler/Collector/form.html.twig'),
-        );
+        $app['data_collector.templates'] = function ($app) {
+            $templates = array(
+                array('config',    '@WebProfiler/Collector/config.html.twig'),
+                array('request',   '@WebProfiler/Collector/request.html.twig'),
+                array('exception', '@WebProfiler/Collector/exception.html.twig'),
+                array('events',    '@WebProfiler/Collector/events.html.twig'),
+                array('logger',    '@WebProfiler/Collector/logger.html.twig'),
+                array('time',      '@WebProfiler/Collector/time.html.twig'),
+                array('router',    '@WebProfiler/Collector/router.html.twig'),
+                array('memory',    '@WebProfiler/Collector/memory.html.twig'),
+                array('form',      '@WebProfiler/Collector/form.html.twig'),
+            );
 
-        if (class_exists('Symfony\Bridge\Twig\Extension\ProfilerExtension')) {
-            $app['data_collector.templates']['twig'] = '@WebProfiler/Collector/twig.html.twig';
-        }
+            if (class_exists('Symfony\Bridge\Twig\Extension\ProfilerExtension')) {
+                $templates['twig'] = '@WebProfiler/Collector/twig.html.twig';
+            }
+
+            return $templates;
+        };
 
         $app['data_collectors'] = function ($app) {
             return array(
@@ -109,17 +113,17 @@ class WebProfilerServiceProvider implements ServiceProviderInterface, Controller
         }
 
         if (class_exists('Symfony\Bridge\Twig\Extension\ProfilerExtension')) {
-            $app['data_collectors'] = $app->share($app->extend('data_collectors', function ($collectors, $app) {
-                $collectors['twig'] = $app->share(function ($app) {
+            $app['data_collectors'] = $app->extend('data_collectors', function ($collectors, $app) {
+                $collectors['twig'] = function ($app) {
                     return new TwigDataCollector($app['twig.profiler.profile']);
-                });
+                };
 
                 return $collectors;
-            }));
-
-            $app['twig.profiler.profile'] = $app->share(function () {
-                return new \Twig_Profiler_Profile();
             });
+
+            $app['twig.profiler.profile'] = function () {
+                return new \Twig_Profiler_Profile();
+            };
         }
 
         $app['web_profiler.controller.profiler'] = function ($app) {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | soon
| Fixed tickets | #59
| License       | MIT

1. PR #58 introduced the following error: "Indirect modification of overloaded element of `Silex\Application` has no effect"
2. PR #55 used `$app->share` to declare services in Silex 1.x, but this method no longer exists in Silex 2 and this was not fixed when the branch 1.0 was merged into the master.
