### PR TITLE
Fix Twig & Routing profilers

### DIFF
--- a/Tests/WebProfilerTest.php
+++ b/Tests/WebProfilerTest.php
@@ -24,8 +24,11 @@ class WebProfilerTest extends WebTestCase
         // Service providers
         $app->register(new Provider\HttpFragmentServiceProvider());
         $app->register(new Provider\ServiceControllerServiceProvider());
-        $app->register(new Provider\TwigServiceProvider());
-        $app->register(new Provider\RoutingServiceProvider());
+        $app->register(new Provider\TwigServiceProvider(), array(
+            'twig.templates' => array(
+                'index.twig' => '<body>OK</body>',
+            ),
+        ));
 
         $app->register(new Provider\WebProfilerServiceProvider(), array(
             'profiler.cache_dir' => __DIR__.'/cache/profiler',
@@ -37,8 +40,8 @@ class WebProfilerTest extends WebTestCase
         $app['session.test'] = true;
 
         // Test route
-        $app->get('/', function () {
-            return '<body>OK</body>';
+        $app->get('/', function () use ($app) {
+            return $app['twig']->render('index.twig');
         });
 
         return $app;
@@ -58,6 +61,7 @@ class WebProfilerTest extends WebTestCase
 
         $crawler = $client->request('GET', $link);
         $this->assertTrue($client->getResponse()->isOk(), 'Profile accessible');
+        $this->assertCount(1, $crawler->filter('#menu-profiler .twig'), 'Twig profiler is enabled');
 
         $client->followRedirects(true);
         $crawler = $client->request('GET', '/_profiler/');

--- a/Tests/WebProfilerTest.php
+++ b/Tests/WebProfilerTest.php
@@ -61,13 +61,42 @@ class WebProfilerTest extends WebTestCase
 
         $crawler = $client->request('GET', $link);
         $this->assertTrue($client->getResponse()->isOk(), 'Profile accessible');
-        $this->assertCount(1, $crawler->filter('#menu-profiler .twig'), 'Twig profiler is enabled');
-
-        $crawler = $client->click($crawler->filter('#menu-profiler .router a')->link());
-        $this->assertCount(1, $crawler->filter('table.routing'), 'Routing profiler is enabled');
 
         $client->followRedirects(true);
         $crawler = $client->request('GET', '/_profiler/');
         $this->assertTrue($client->getResponse()->isOk(), 'Profiler accessible');
+    }
+
+    public function testRoutingProfiler()
+    {
+        $client = $this->createClient();
+        $client->request('GET', '/');
+
+        $link = $client->getResponse()->headers->get('X-Debug-Token-Link');
+        $crawler = $client->request('GET', $link);
+
+        $crawler = $client->click($crawler->selectLink('Routing')->link());
+        $this->assertTrue($client->getResponse()->isOk(), 'Routing profiler is enabled');
+        $this->assertCount(1, $crawler->filter('h2:contains("Routing for")'), 'Routing profiler is working');
+    }
+
+    public function testTwigProfiler()
+    {
+        if (!class_exists('Symfony\Bridge\Twig\Extension\ProfilerExtension')) {
+            $this->markTestSkipped(
+              'Twig profiler extension is available in Symfony 2.7+'
+            );
+        }
+
+        $client = $this->createClient();
+        $client->request('GET', '/');
+
+        $link = $client->getResponse()->headers->get('X-Debug-Token-Link');
+        $crawler = $client->request('GET', $link);
+
+        $crawler = $client->click($crawler->selectLink('Twig')->link());
+        $this->assertTrue($client->getResponse()->isOk(), 'Twig profiler is enabled');
+        $this->assertCount(1, $crawler->filter('h2:contains("Twig Stats")'), 'Twig profiler is working');
+
     }
 }

--- a/Tests/WebProfilerTest.php
+++ b/Tests/WebProfilerTest.php
@@ -63,6 +63,9 @@ class WebProfilerTest extends WebTestCase
         $this->assertTrue($client->getResponse()->isOk(), 'Profile accessible');
         $this->assertCount(1, $crawler->filter('#menu-profiler .twig'), 'Twig profiler is enabled');
 
+        $crawler = $client->click($crawler->filter('#menu-profiler .router a')->link());
+        $this->assertCount(1, $crawler->filter('table.routing'), 'Routing profiler is enabled');
+
         $client->followRedirects(true);
         $crawler = $client->request('GET', '/_profiler/');
         $this->assertTrue($client->getResponse()->isOk(), 'Profiler accessible');

--- a/WebProfilerServiceProvider.php
+++ b/WebProfilerServiceProvider.php
@@ -131,7 +131,7 @@ class WebProfilerServiceProvider implements ServiceProviderInterface, Controller
         };
 
         $app['web_profiler.controller.router'] = function ($app) {
-            return new RouterController($app['profiler'], $app['twig'], isset($app['url_matcher']) ? $app['url_matcher'] : null, $app['routes']);
+            return new RouterController($app['profiler'], $app['twig'], isset($app['request_matcher']) ? $app['request_matcher'] : null, $app['routes']);
         };
 
         $app['web_profiler.controller.exception'] = function ($app) {

--- a/WebProfilerServiceProvider.php
+++ b/WebProfilerServiceProvider.php
@@ -73,7 +73,7 @@ class WebProfilerServiceProvider implements ServiceProviderInterface, Controller
             );
 
             if (class_exists('Symfony\Bridge\Twig\Extension\ProfilerExtension')) {
-                $templates['twig'] = '@WebProfiler/Collector/twig.html.twig';
+                $templates[] = array('twig', '@WebProfiler/Collector/twig.html.twig');
             }
 
             return $templates;


### PR DESCRIPTION
1. Fix the Twig template definition to show the "Twig" item in the profiler menu.
2. Use the service `request_matcher` which replace `url_matcher` in Silex 2.

[Tests are failing](https://travis-ci.org/GromNaN/Silex-WebProfiler/builds/62699523) due to an incompatibility between `symfony/webprofiler-bundle 2.7` and `symfony/http-kernel 2.6`. This issue is resolved by https://github.com/symfony/symfony/pull/14645

| Q             | A
| ------------- | ---
| Bug fix?      | yes
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | no
| Fixed tickets | -
| License       | MIT