### PR TITLE
Add missing UrlGeneratorServiceProvider to the dependency list

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -23,14 +23,16 @@ And enable it in your application:
     ));
 
 The provider depends on ``ServiceControllerServiceProvider``,
-``TwigServiceProvider``, and ``HttpFragmentServiceProvider`` so you also need
-to enable those if that's not already the case:
+``TwigServiceProvider``, ``UrlGeneratorServiceProvider`` and
+``HttpFragmentServiceProvider`` so you also need to enable those
+if that's not already the case:
 
 .. code-block:: php
 
     $app->register(new Provider\HttpFragmentServiceProvider());
     $app->register(new Provider\ServiceControllerServiceProvider());
     $app->register(new Provider\TwigServiceProvider());
+    $app->register(new Provider\UrlGeneratorServiceProvider());
 
 If you are using ``FormServiceProvider``, the ``WebProfilerServiceProvider``
 will detect that and enable the corresponding panels.


### PR DESCRIPTION
I was running Silex without any providers enabled and found that to enable WebProfilerServiceProvider, I had to also enable UrlGeneratorServiceProvider.

When not enabled, I'd get:

> `Fatal error: Uncaught InvalidArgumentException: Identifier "url_generator" is not defined. in /home/j/workspace/QueryrAPI/vendor/pimple/pimple/lib/Pimple.php:78 Stack trace: #0 /home/j/workspace/QueryrAPI/vendor/silex/web-profiler/Silex/Provider/WebProfilerServiceProvider.php(136): Pimple->offsetGet('url_generator') #1 /home/j/workspace/QueryrAPI/vendor/pimple/pimple/lib/Pimple.php(126): Silex\Provider\WebProfilerServiceProvider->Silex\Provider\{closure}(Object(Silex\Application)) #2 /home/j/workspace/QueryrAPI/vendor/pimple/pimple/lib/Pimple.php(83): Pimple::{closure}(Object(Silex\Application)) #3 /home/j/workspace/QueryrAPI/vendor/silex/web-profiler/Silex/Provider/WebProfilerServiceProvider.php(235): Pimple->offsetGet('web_profiler.to...') #4 /home/j/workspace/QueryrAPI/vendor/silex/silex/src/Silex/Application.php(197): Silex\Provider\WebProfilerServiceProvider->boot(Object(Silex\Application)) #5 /home/j/workspace/QueryrAPI/vendor/silex/silex/src/Silex/Application.php(577): Silex\Application->boot() #6 /home/j/workspace in /home/j/workspace/QueryrAPI/vendor/pimple/pimple/lib/Pimple.php on line 78`