### PR TITLE
Allow symfony 3.1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ version:
 
 .. code-block:: bash
 
-    composer require silex/web-profiler ~2.0@dev
+    composer require 'silex/web-profiler:^2.0'
 
 And enable it in your application:
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "silex/silex": "^2.0",
-        "symfony/web-profiler-bundle": "^2.8|3.0.*",
+        "symfony/web-profiler-bundle": "^2.8|^3.0",
         "symfony/twig-bridge": "^2.8|^3.0",
         "symfony/stopwatch": "^2.8|^3.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -10,17 +10,17 @@
         }
     ],
     "require": {
-        "silex/silex": "~2.0",
-        "symfony/web-profiler-bundle": "~2.8|3.0.*",
-        "symfony/twig-bridge": "~2.8|3.0.*",
-        "symfony/stopwatch": "~2.8|3.0.*"
+        "silex/silex": "^2.0",
+        "symfony/web-profiler-bundle": "^2.8|3.0.*",
+        "symfony/twig-bridge": "^2.8|^3.0",
+        "symfony/stopwatch": "^2.8|^3.0"
     },
     "require-dev": {
-        "symfony/browser-kit": "~2.8|3.0.*",
-        "symfony/css-selector": "~2.8|3.0.*",
-        "symfony/debug-bundle": "~2.8|3.0.*",
-        "symfony/security": "~2.8|3.0.*",
-        "symfony/security-bundle": "~2.8|3.0.*"
+        "symfony/browser-kit": "^2.8|^3.0",
+        "symfony/css-selector": "^2.8|^3.0",
+        "symfony/debug-bundle": "^2.8|^3.0",
+        "symfony/security": "^2.8|^3.0",
+        "symfony/security-bundle": "^2.8|^3.0"
     },
     "autoload": {
         "psr-0": { "Silex\\Provider\\": "" }

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,9 @@
         "symfony/twig-bridge": "^2.8|^3.0",
         "symfony/stopwatch": "^2.8|^3.0"
     },
+    "conflict": {
+        "symfony/web-profiler-bundle": "3.1.0"
+    },
     "require-dev": {
         "symfony/browser-kit": "^2.8|^3.0",
         "symfony/css-selector": "^2.8|^3.0",


### PR DESCRIPTION
As I was updating my skeleton app, I found out the webprofiler did not support symfony 3.1 in composer.json.
So I tried to update it.

Everything works great, except for the web-profiler-bundle.
This PR broke it: https://github.com/symfony/symfony/pull/17589

I don't know the best way to fix that. Maybe you have an idea? (I'm not that familiar with the silex and symfony development)