### PR TITLE
register FormDataCollector with container to make it singleton

### DIFF
--- a/WebProfilerServiceProvider.php
+++ b/WebProfilerServiceProvider.php
@@ -116,9 +116,10 @@ class WebProfilerServiceProvider implements ServiceProviderInterface, Controller
 
         if (isset($app['form.resolved_type_factory']) && class_exists('\Symfony\Component\Form\Extension\DataCollector\FormDataCollector')) {
             $app['data_collectors.form.extractor'] = function () { return new FormDataExtractor(); };
+            $app['data_collectors.form.collector'] = function ($app) { return new FormDataCollector($app['data_collectors.form.extractor']); };
 
             $app->extend('data_collectors', function ($collectors, $app) {
-                $collectors['form'] = function ($app) { return new FormDataCollector($app['data_collectors.form.extractor']); };
+                $collectors['form'] = function ($app) { return $app['data_collectors.form.collector']; };
 
                 return $collectors;
             });


### PR DESCRIPTION
The issue is the form section of webprofiler is always empty. This is because one instance of `FormDataCollector` collects form information via form events, but when webprofiler is rendered, it gets a another newly instantiated `FormDataCollector` which is obviously empty.

My solution registers `FormDataCollector` as a service to $app and returns it. This way single instance of `FormDataCollector` collects form data then webprofiler gets that same instance, so it can show form information.