### PR TITLE
Add @Twig/layout.html.twig to fix intercept_redirects - fixes #109 #34

### DIFF
--- a/Resources/views/Twig/layout.html.twig
+++ b/Resources/views/Twig/layout.html.twig
@@ -1,0 +1,5 @@
+{% extends '@WebProfiler/Profiler/base.html.twig' %}
+
+{% block body %}
+
+{% endblock %}

--- a/WebProfilerServiceProvider.php
+++ b/WebProfilerServiceProvider.php
@@ -308,6 +308,8 @@ class WebProfilerServiceProvider implements ServiceProviderInterface, Controller
 
         $app->extend('twig.loader.filesystem', function ($loader, $app) {
             $loader->addPath($app['profiler.templates_path'], 'WebProfiler');
+            $loader->addPath(__DIR__.'/Resources/views/Twig', 'Twig');
+
             if ($app['profiler.templates_path.debug']) {
                 $loader->addPath($app['profiler.templates_path.debug'], 'Debug');
             }


### PR DESCRIPTION
This commit adds a minimal `@Twig/layout.html.twig` template with
default content block. This is required for `intercept_redirects`
functionality to work, as `toolbar_redirect.html.twig` template extends
`@Twig/layout.html.twig`.

The decision to add a "placeholder" template came because:

1. We cannot rely on using the original templateas it is for symfony
   bundle and will not render in Silex WebProfiler correctly. This does
   not cause problems with other partials that Silex WebProfiler is
   using as no other partials depend on `layout.html.twig`.
2. Another way to fix this would be making a change to upstream
   `symfony/profiler-bundle`. However, I believe having this sort of
   fix wouldn't make sense for the bundle and we need a working fix
   anyway until there are any changes we could request from upstream (I
   am not sure if we even should).

Full information on #109 
Fixes #109 #34 