### PR TITLE
Add cache panel to the web profiler

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,9 @@
         "symfony/phpunit-bridge": "~3.2",
         "symfony/security": "^2.8|^3.0",
         "symfony/security-bundle": "^2.8|^3.0",
-        "symfony/translation": "^2.8|^3.0"
+        "symfony/translation": "^2.8|^3.0",
+        "symfony/var-dumper": "^3.3@dev",
+        "symfony/cache": "^3.3@dev"
     },
     "autoload": {
         "psr-4": { "Silex\\Provider\\": "" }


### PR DESCRIPTION
This will enable the cache panel once silexphp/Silex#1524 gets merged and `symfony 3.3` is released.

I had to add `@dev` entries to `composer.json` so composer would run, I'll update the file when `3.3` is ready.

I also had to check if `symfony/web-profiler-bundle >= 3.3` was available:

As `profiler.templates_path` was registered as a lazy/dynamic parameter and I didn't want to initialize anything lazy at this stage, I changed its definition and made it a regular parameter.

If you don't like this I could change it back, but that means we'll have to do something like the following instead 😢 :

```php

if (isset($app['cache.pools']) && class_exists('Symfony\Component\Cache\DataCollector\CacheDataCollector')) {
    $app->extend('cache.pools', function ($pools) {
        if (is_file($app['profiler.templates_path'].'/Collector/cache.html.twig')) {
            // ...
        }

        return $pools;
    });
    $app->extend('data_collector.templates', function ($templates) {
        if (is_file($app['profiler.templates_path'].'/Collector/cache.html.twig')) {
            // ...
        }

        return $templates;
    });
    $app->extend('data_collectors', function ($collectors) {
        if (is_file($app['profiler.templates_path'].'/Collector/cache.html.twig')) {
            // ...
        }

        return $collectors;
    });
}
```
