### PR TITLE
Add twig-bundle support

### DIFF
--- a/WebProfilerServiceProvider.php
+++ b/WebProfilerServiceProvider.php
@@ -309,6 +309,7 @@ class WebProfilerServiceProvider implements ServiceProviderInterface, Controller
 
         $app->extend('twig.loader.filesystem', function ($loader, $app) {
             $loader->addPath($app['profiler.templates_path'], 'WebProfiler');
+            $loader->addPath($app['profiler.templates_path.twig'], 'Twig');
             if ($app['profiler.templates_path.debug']) {
                 $loader->addPath($app['profiler.templates_path.debug'], 'Debug');
             }
@@ -318,6 +319,12 @@ class WebProfilerServiceProvider implements ServiceProviderInterface, Controller
 
         $app['profiler.templates_path'] = function () {
             $r = new \ReflectionClass('Symfony\Bundle\WebProfilerBundle\EventListener\WebDebugToolbarListener');
+
+            return dirname(dirname($r->getFileName())).'/Resources/views';
+        };
+
+        $app['profiler.templates_path.twig'] = function () {
+            $r = new \ReflectionClass('Symfony\Bundle\TwigBundle\Controller\ExceptionController');
 
             return dirname(dirname($r->getFileName())).'/Resources/views';
         };

--- a/composer.json
+++ b/composer.json
@@ -12,6 +12,7 @@
     "require": {
         "silex/silex": "^2.0",
         "symfony/web-profiler-bundle": "^2.8|^3.0",
+        "symfony/twig-bundle": "^2.8|^3.0",
         "symfony/twig-bridge": "^2.8|^3.0",
         "symfony/stopwatch": "^2.8|^3.0"
     },


### PR DESCRIPTION
Adds `symfony/twig-bundle` to the list of dependencies and registers the `@Twig` templates namespace.

- This fixes #109 and closes #110
- It also _fixes_ the exception page (eg: on `3.3` we get the fancy new page 😄 )