### PR TITLE
upgrade to Symfony 4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,16 +9,10 @@ cache:
 
 matrix:
     include:
-        - php: 5.5
-        - php: 5.6
-        - php: 7.0
         - php: 7.1
-          env: SYMFONY_DEPS_VERSION=3
-        - php: hhvm
+        - php: 7.2
 
 before_script:
-    - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '3.0' ]; then sed -i 's/~2\.8|3\.0\.\*/3.0.*@dev/g' composer.json; composer update; fi"
-    - sh -c "if [ '$SYMFONY_DEPS_VERSION' = '' ]; then sed -i 's/~2\.8|3\.0\.\*/2.8.*@dev/g' composer.json; composer update; fi"
     - travis_retry composer install
 
 script:

--- a/WebProfilerServiceProvider.php
+++ b/WebProfilerServiceProvider.php
@@ -237,7 +237,7 @@ class WebProfilerServiceProvider implements ServiceProviderInterface, Controller
         }
 
         $app['web_profiler.controller.profiler'] = function ($app) use ($baseDir) {
-            return new ProfilerController($app['url_generator'], $app['profiler'], $app['twig'], $app['data_collector.templates'], $app['web_profiler.debug_toolbar.position'], null, $baseDir);
+            return new ProfilerController($app['url_generator'], $app['profiler'], $app['twig'], $app['data_collector.templates'], null, $baseDir);
         };
 
         $app['web_profiler.controller.router'] = function ($app) {
@@ -251,7 +251,7 @@ class WebProfilerServiceProvider implements ServiceProviderInterface, Controller
         $app['web_profiler.toolbar.listener'] = function ($app) {
             $mode = $app['web_profiler.debug_toolbar.enable'] ? WebDebugToolbarListener::ENABLED : WebDebugToolbarListener::DISABLED;
 
-            return new WebDebugToolbarListener($app['twig'], $app['web_profiler.debug_toolbar.intercept_redirects'], $mode, $app['web_profiler.debug_toolbar.position'], $app['url_generator']);
+            return new WebDebugToolbarListener($app['twig'], $app['web_profiler.debug_toolbar.intercept_redirects'], $mode, $app['url_generator']);
         };
 
         $app['profiler'] = function ($app) {
@@ -272,7 +272,6 @@ class WebProfilerServiceProvider implements ServiceProviderInterface, Controller
         $app['profiler.only_exceptions'] = false;
         $app['profiler.only_master_requests'] = false;
         $app['web_profiler.debug_toolbar.enable'] = true;
-        $app['web_profiler.debug_toolbar.position'] = 'bottom';
         $app['web_profiler.debug_toolbar.intercept_redirects'] = false;
 
         $app['profiler.listener'] = function ($app) {

--- a/composer.json
+++ b/composer.json
@@ -11,22 +11,23 @@
     ],
     "require": {
         "silex/silex": "^2.0",
-        "symfony/web-profiler-bundle": "^2.8|^3.0",
-        "symfony/twig-bundle": "^2.8|^3.0",
-        "symfony/twig-bridge": "^2.8|^3.0",
-        "symfony/stopwatch": "^2.8|^3.0"
+        "symfony/web-profiler-bundle": "^4.0",
+        "symfony/twig-bundle": "^4.0",
+        "symfony/twig-bridge": "^4.0",
+        "symfony/stopwatch": "^4.0"
     },
     "conflict": {
         "symfony/web-profiler-bundle": "3.1.0"
     },
     "require-dev": {
-        "symfony/browser-kit": "^2.8|^3.0",
-        "symfony/css-selector": "^2.8|^3.0",
-        "symfony/debug-bundle": "^2.8|^3.0",
-        "symfony/phpunit-bridge": "~3.2",
-        "symfony/security": "^2.8|^3.0",
-        "symfony/security-bundle": "^2.8|^3.0",
-        "symfony/translation": "^2.8|^3.0"
+        "phpunit/phpunit": "4.x|5.x|6.x",
+        "symfony/browser-kit": "^4.0",
+        "symfony/css-selector": "^4.0",
+        "symfony/debug-bundle": "^4.0",
+        "symfony/phpunit-bridge": "^4.0",
+        "symfony/security": "^4.0",
+        "symfony/security-bundle": "^4.0",
+        "symfony/translation": "^4.0"
     },
     "autoload": {
         "psr-4": { "Silex\\Provider\\": "" }


### PR DESCRIPTION
See issue #131 

It allows to use web profiler with Symfony 4.

It introduce breaking changes while upgrading to sf4, so I couldn't keep retro-compatibility to SF < 4 for this new version.